### PR TITLE
Fix public path and chunk ordering

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,7 @@ const defaultConfig = {
     filename: "[name].js",
     chunkFilename: "[name].js",
     path: join(context, "dist"),
-    publicPath: "",
+    publicPath: "/",
   },
   node: {
     fs: "empty",
@@ -44,7 +44,9 @@ const defaultConfig = {
   plugins: [
     new DashboardPlugin(),
     new HtmlWebpackPlugin({
-      chunksSortMode: "none",
+      chunksSortMode: "manual",
+      // The `config` chunk must come before `main` to make sure that runtime configuration variables are loaded
+      chunks: ["config", "main"],
       template: join(context, "public/index.html"),
     }),
   ],


### PR DESCRIPTION
# Why

This PR fixes two issues in the production build scripts:
* the production assets are not prefixed with a slash, making them unreachable if the app is accessed through a non-root route.
* `config.js` is inserted after `main.js`, breaking the app which attempts to start without runtime configuration variables.

# In this PR

* public path changes to `"/"`.
* chunk sort order is set to manual, with explicitly ordered chunks `[ "config", "main" ]`

# Please try to break

* dev environment works as expected.
* in a production build, refreshing the screen at a non-root route still serves assets.
* `config.js` and `main.js` are loaded in the correct order.