### PR TITLE
**Fix:** Hoist legacy artefacts and fix path in precommit

### DIFF
--- a/assets/pre-commit
+++ b/assets/pre-commit
@@ -4,7 +4,7 @@ const { execSync } = require("child_process");
 const projectDir = execSync(`find ${process.cwd()}/node_modules`)
   .toString()
   .split("\n")[0];
-const operationalScripts = `${projectDir}/operational-scripts`;
+const operationalScripts = `${projectDir}/@operational/scripts`;
 
 try {
   return execSync(`${projectDir}/.bin/lint-staged -c ${operationalScripts}/assets/.lintstagedrc`, {

--- a/install.js
+++ b/install.js
@@ -37,7 +37,7 @@ const installGitIgnore = (packageRoot, task) => {
       .filter(line => !legacyArtefacts.includes(line))
       .join("\n");
     writeFileSync(dest, fileContents);
-    execSync(`echo ".prettierrc\ntsconfig.json" >> ${dest}`);
+    execSync(`echo ".prettierrc\ntsconfig.json\ntslint.json" >> ${dest}`);
     task.skip(".gitignore already exists. Amending...");
     return;
   }

--- a/install.js
+++ b/install.js
@@ -4,8 +4,8 @@ const { execSync } = require("child_process");
 const { sync: pkgDir } = require("pkg-dir");
 const Listr = require("listr");
 
+const legacyArtefacts = ["tslint.json", "tsconfig.json", ".prettierrc"];
 const removeLegacyArtefacts = packageRoot => {
-  const legacyArtefacts = ["tslint.json", "tsconfig.json", ".prettierrc"];
   const removeArtefact = artefact => {
     const contextArtefactPath = join(packageRoot, artefact);
     const ourArtefactPath = join(__dirname, artefact);

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,21 +1,14 @@
-const { join } = require('path')
+const { join } = require("path");
 
 module.exports = {
-    "globals": {
-      "ts-jest": {
-        "tsConfigFile": join(__dirname, "tsconfig.jest.json")
-      }
+  globals: {
+    "ts-jest": {
+      tsConfigFile: join(__dirname, "tsconfig.jest.json"),
     },
-    "transform": {
-      "^.+\\.tsx?$": "ts-jest"
-    },
-    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx)$",
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "jsx",
-      "json",
-      "node"
-    ]
-  }
+  },
+  transform: {
+    "^.+\\.tsx?$": "ts-jest",
+  },
+  testRegex: "(/__tests__/.*|\\.(test|spec))(?<!d)\\.(ts|tsx)$",
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+};

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "engines": {
     "vscode": "^1.22.0"
   },
-  "version": "1.0.1-de63f63",
+  "version": "1.0.1-7555569",
   "private": false,
   "license": "MIT",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "engines": {
     "vscode": "^1.22.0"
   },
-  "version": "1.0.1-8bc7044",
+  "version": "1.0.1-de63f63",
   "private": false,
   "license": "MIT",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "engines": {
     "vscode": "^1.22.0"
   },
-  "version": "1.0.1",
+  "version": "1.0.1-8bc7044",
   "private": false,
   "license": "MIT",
   "bin": {

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,6 +1,5 @@
 {
   "extends": "./tsconfig",
-  "include": ["../../../src"], // because this usually lives in node_modules/@operational/scripts
   "compilerOptions": {
     "module": "commonjs"
   }


### PR DESCRIPTION
# Why
![image](https://user-images.githubusercontent.com/9947422/44572497-416d3d80-a784-11e8-9751-0907e760c68c.png)

and

![image](https://user-images.githubusercontent.com/9947422/44572508-4a5e0f00-a784-11e8-8b8f-604fc6cdc8a0.png)


<!-- Describe why this pull request exists. What problem does it solve? -->

# In this PR
Fixes for both cases

<!-- Describe what changes are proposed -->

# How to test / Please try to break
- `npm install @operational/scripts@next` in your project should have no errors
- a commit should work with correct precommit

<!-- What should be tested? -->
