### PR TITLE
Fix/tests and logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,9 @@ typings/
 # dotenv environment variables file
 .env
 
+lib
+dist
+
 #!! ERROR: vscode is undefined. Use list command to see defined gitignore types !!#
 
 

--- a/install.js
+++ b/install.js
@@ -22,7 +22,7 @@ const removeLegacyArtefacts = packageRoot => {
       execSync(`git rm --cached ${contextArtefactPath}`, {
         stdio: "ignore",
       });
-    } catch {
+    } catch (e) {
       // Here's the fail silently part.
     }
   };

--- a/install.js
+++ b/install.js
@@ -18,9 +18,13 @@ const removeLegacyArtefacts = packageRoot => {
      * since they're copied over postinstall,
      * fail silently if they don't exist.
      */
-    execSync(`git rm --cached ${contextArtefactPath}`, {
-      stdio: "ignore",
-    });
+    try {
+      execSync(`git rm --cached ${contextArtefactPath}`, {
+        stdio: "ignore",
+      });
+    } catch {
+      // Here's the fail silently part.
+    }
   };
   legacyArtefacts.forEach(removeArtefact);
 };

--- a/install.js
+++ b/install.js
@@ -12,13 +12,15 @@ const removeLegacyArtefacts = packageRoot => {
     const ourArtefactPath = join(__dirname, artefact);
     removeSync(contextArtefactPath);
     copySync(ourArtefactPath, contextArtefactPath);
-    
+
     /**
-      * Remove versioning of copied-over assets
-      * since they're copied over postinstall, 
-      * fail "silently" if they don't exist.
-      */
-    execSync(`git rm --cached ${contextArtefactPath} || echo "No cached artefacts to remove. Continuing…"`);
+     * Remove versioning of copied-over assets
+     * since they're copied over postinstall,
+     * fail silently if they don't exist.
+     */
+    execSync(`git rm --cached ${contextArtefactPath}`, {
+      stdio: "ignore",
+    });
   };
   legacyArtefacts.forEach(removeArtefact);
 };

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "engines": {
     "vscode": "^1.22.0"
   },
-  "version": "1.1.0-1",
+  "version": "1.1.0",
   "private": false,
   "license": "MIT",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "engines": {
     "vscode": "^1.22.0"
   },
-  "version": "1.1.0-2",
+  "version": "1.1.0-3",
   "private": false,
   "license": "MIT",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "engines": {
     "vscode": "^1.22.0"
   },
-  "version": "1.1.0-3",
+  "version": "1.1.0-4",
   "private": false,
   "license": "MIT",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "engines": {
     "vscode": "^1.22.0"
   },
-  "version": "1.1.0-4",
+  "version": "1.1.0-5",
   "private": false,
   "license": "MIT",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "engines": {
     "vscode": "^1.22.0"
   },
-  "version": "1.0.2",
+  "version": "1.1.0-1",
   "private": false,
   "license": "MIT",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "engines": {
     "vscode": "^1.22.0"
   },
-  "version": "1.1.0",
+  "version": "1.1.0-2",
   "private": false,
   "license": "MIT",
   "bin": {

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,5 +1,6 @@
 {
   "extends": "./tsconfig",
+  "include": ["../../../src"],
   "compilerOptions": {
     "module": "commonjs"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "exclude": ["node_modules", "dist", "lib"],
+  "exclude": ["node_modules", "dist", "lib", "__tests__", "**/*.test*", "**/*.spec*"],
   "include": ["src"],
   "compilerOptions": {
     "skipLibCheck": true,


### PR DESCRIPTION
# Why
We broke the ability to execute tests when refactoring for windows. Also, the pathspec would fail on git on install and corrupt the output.

<!-- Describe why this pull request exists. What problem does it solve? -->

# In this PR
- A cleaner postinstall script, with a proper silent failure.
- A _working_ jest tsconfig.
- Removed tests from final packaged output.

<!-- Describe what changes are proposed -->

# How to Test / Please try to break
- `npm install @operational/scripts@next` should work properly
- `yarn test` in your project should work
- `yarn build --for npm` should not have tests in `lib

<!-- What should be tested? -->
