### PR TITLE
Include `/lib` in npm by default

### DIFF
--- a/install.js
+++ b/install.js
@@ -88,6 +88,7 @@ const addScripts = packageRoot => {
 
     packageJson.scripts.prepublishOnly = "operational-scripts prepare";
     packageJson.scripts.test = "operational-scripts test";
+    packageJson.files = ["lib"];
     delete packageJson.scripts.precommit;
     delete packageJson.jest;
     delete packageJson.test;


### PR DESCRIPTION
# Why

#9 

# In this PR

Add default `files` to avoid empty (without lib folder) publish on npm

# How to Test / Please try to break

- init a project
- publish on npm (you can use `npm run prepublishOnly && npm pack` to simulate the output)
