### PR TITLE
Expose `process.env.VERSION` in the application

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,27 +12,20 @@ const pathToOwnWebpackConfig = join(context, "webpack.config.js");
 const hasOwnWebpackConfig = existsSync(pathToOwnWebpackConfig);
 const webpackConfigToMerge = hasOwnWebpackConfig ? require(pathToOwnWebpackConfig) : {};
 
-/**
- * Return the current version of the app.
- *
- * Format: `${package.json:version}-${gitShortSha}`
- * or just the package version if git is not available.
- */
+function getGitShortSha() {
+  return execSync("git rev-parse --short HEAD")
+    .toString()
+    .trim();
+}
+
 function getVersion() {
   const package = JSON.parse(readFileSync(join(context, "package.json")));
-  let version = package.version;
-
   try {
-    version +=
-      "-" +
-      execSync("git rev-parse --short HEAD")
-        .toString()
-        .trim();
+    return `${package.version}-${getGitShortSha()}`;
   } catch (e) {
     console.log(e.message);
+    return package.version;
   }
-
-  return version;
 }
 
 const defaultConfig = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,13 +12,12 @@ const pathToOwnWebpackConfig = join(context, "webpack.config.js");
 const hasOwnWebpackConfig = existsSync(pathToOwnWebpackConfig);
 const webpackConfigToMerge = hasOwnWebpackConfig ? require(pathToOwnWebpackConfig) : {};
 
-function getGitShortSha() {
-  return execSync("git rev-parse --short HEAD")
+const getGitShortSha = () =>
+  execSync("git rev-parse --short HEAD")
     .toString()
     .trim();
-}
 
-function getVersion() {
+const getVersion = () => {
   const package = JSON.parse(readFileSync(join(context, "package.json")));
   try {
     return `${package.version}-${getGitShortSha()}`;
@@ -26,7 +25,7 @@ function getVersion() {
     console.log(e.message);
     return package.version;
   }
-}
+};
 
 const defaultConfig = {
   mode: process.env.NODE_ENV || "development",


### PR DESCRIPTION
# Why

In the developer life, it can sometime be hard to know which version we are looking on production.

# In this PR

This PR just expose the actual git version under `process.env.GIT_VERSION`, so we can easily expose this version somewhere in any application.

# How to Test / Please try to break

Add `console.log(process.env.GIT_VERSION)` somewhere in your project
