### PR TITLE
Only override npm scripts if they do not contain defaults

### DIFF
--- a/__tests__/install.test.js
+++ b/__tests__/install.test.js
@@ -1,0 +1,30 @@
+const installMethods = require("../install.js");
+
+describe("replaceScripts", () => {
+  it("replaces scripts", () => {
+    const packageJson = {
+      scripts: {
+        // This is left intact because it already contains the specified default script
+        start: "startScript && echo 'hello'",
+        // The `build` script is added since it doesn't exist
+        // The `test` script is replaced since it doesn't contain the specified default script
+        test: "wrongTestScript"
+      },
+    };
+    installMethods.replaceScripts(
+      {
+        start: "startScript",
+        build: "buildScript",
+        test: "testScript",
+      },
+      packageJson,
+    );
+    expect(packageJson).toEqual({
+      scripts: {
+        start: "startScript && echo 'hello'",
+        build: "buildScript",
+        test: "testScript"
+      },
+    });
+  });
+});

--- a/__tests__/install.test.js
+++ b/__tests__/install.test.js
@@ -1,17 +1,17 @@
 const installMethods = require("../install.js");
 
-describe("replaceScripts", () => {
+describe("addDefaultScripts", () => {
   it("replaces scripts", () => {
     const packageJson = {
       scripts: {
-        // This is left intact because it already contains the specified default script
+        // This is left intact because it is already set
         start: "startScript && echo 'hello'",
         // The `build` script is added since it doesn't exist
-        // The `test` script is replaced since it doesn't contain the specified default script
-        test: "wrongTestScript"
+        // The `test` script is replaced since it is falsy
+        test: ""
       },
     };
-    installMethods.replaceScripts(
+    installMethods.addDefaultScripts(
       {
         start: "startScript",
         build: "buildScript",

--- a/install.js
+++ b/install.js
@@ -79,7 +79,6 @@ const installStaticFiles = (packageRoot, task) => {
  */
 const replaceScripts = (scripts, packageJson) => {
   Object.entries(scripts).forEach(([scriptName, scriptContents]) => {
-    const scriptName = scriptData[0]
     const scriptContents = scriptData[1]
     if (!packageJson.scripts[scriptName]) {
       packageJson.scripts[scriptName] = scriptContents;

--- a/install.js
+++ b/install.js
@@ -78,7 +78,7 @@ const installStaticFiles = (packageRoot, task) => {
  * This method mutates the `packageJson` argument passed in.
  */
 const replaceScripts = (scripts, packageJson) => {
-  Object.entries(scripts).forEach(scriptData => {
+  Object.entries(scripts).forEach(([scriptName, scriptContents]) => {
     const scriptName = scriptData[0]
     const scriptContents = scriptData[1]
     if (!packageJson.scripts[scriptName]) {

--- a/install.js
+++ b/install.js
@@ -77,16 +77,11 @@ const installStaticFiles = (packageRoot, task) => {
  * it is inserted with everything else removed.
  * This method mutates the `packageJson` argument passed in.
  */
-const replaceScripts = (scripts, packageJson) => {
+const addDefaultScripts = (scripts, packageJson) => {
   Object.entries(scripts).forEach(([scriptName, scriptContents]) => {
     if (!packageJson.scripts[scriptName]) {
       packageJson.scripts[scriptName] = scriptContents;
-      return;
     }
-    if (packageJson.scripts[scriptName].includes(scriptContents)) {
-      return;
-    }
-    packageJson.scripts[scriptName] = scriptContents;
   });
 };
 
@@ -99,7 +94,7 @@ const addScripts = packageRoot => {
       packageJson.scripts = {};
     }
 
-    replaceScripts(
+    addDefaultScripts(
       {
         start: "operational-scripts start",
         build: "operational-scripts build",
@@ -116,7 +111,7 @@ const addScripts = packageRoot => {
     delete packageJson.lint;
     delete packageJson["lint-staged"];
 
-    writeFileSync(pathToPackageJson, JSON.stringify(packageJson, 2, 2));
+    writeFileSync(pathToPackageJson, JSON.stringify(packageJson, null, 2));
   } catch (e) {
     throw e;
   }
@@ -132,7 +127,7 @@ const addMain = (packageRoot, task) => {
       return;
     }
     packageJson.main = "./dist/main.js";
-    writeFileSync(pathToPackageJson, JSON.stringify(packageJson, 2, 2));
+    writeFileSync(pathToPackageJson, JSON.stringify(packageJson, null, 2));
   } catch (e) {
     throw e;
   }
@@ -189,5 +184,5 @@ try {
 
 // Methods exported for tests
 module.exports = {
-  replaceScripts: replaceScripts
+  addDefaultScripts
 }

--- a/install.js
+++ b/install.js
@@ -70,6 +70,28 @@ const installStaticFiles = (packageRoot, task) => {
   }
 };
 
+/**
+ * Replace a script inside `package.json` if it doesn't contain the expected default script.
+ * This ensures that users can add script snippets representing custom needs inside these scripts
+ * without having their changes overridden on installation. If the default script is not contained, however,
+ * it is inserted with everything else removed.
+ * This method mutates the `packageJson` argument passed in.
+ */
+const replaceScripts = (scripts, packageJson) => {
+  Object.entries(scripts).forEach(scriptData => {
+    const scriptName = scriptData[0]
+    const scriptContents = scriptData[1]
+    if (!packageJson.scripts[scriptName]) {
+      packageJson.scripts[scriptName] = scriptContents;
+      return;
+    }
+    if (packageJson.scripts[scriptName].includes(scriptContents)) {
+      return;
+    }
+    packageJson.scripts[scriptName] = scriptContents;
+  });
+};
+
 const addScripts = packageRoot => {
   const pathToPackageJson = join(packageRoot, "package.json");
 
@@ -79,16 +101,15 @@ const addScripts = packageRoot => {
       packageJson.scripts = {};
     }
 
-    // Cover your eyes, functional friends – mutation time!
-    if (!get(packageJson, "scripts.start", "").includes("operational-scripts")) {
-      packageJson.scripts.start = "operational-scripts start";
-    }
-    if (!get(packageJson, "scripts.build", "").includes("operational-scripts")) {
-      packageJson.scripts.build = "operational-scripts build";
-    }
-
-    packageJson.scripts.prepublishOnly = "operational-scripts prepare";
-    packageJson.scripts.test = "operational-scripts test";
+    replaceScripts(
+      {
+        start: "operational-scripts start",
+        build: "operational-scripts build",
+        prepublishOnly: "operational-scripts prepare",
+        test: "operational-scripts test",
+      },
+      packageJson,
+    );
     packageJson.files = ["lib"];
     delete packageJson.scripts.precommit;
     delete packageJson.jest;
@@ -97,7 +118,7 @@ const addScripts = packageRoot => {
     delete packageJson.lint;
     delete packageJson["lint-staged"];
 
-    writeFileSync(pathToPackageJson, JSON.stringify(packageJson));
+    writeFileSync(pathToPackageJson, JSON.stringify(packageJson, 2, 2));
   } catch (e) {
     throw e;
   }
@@ -113,7 +134,7 @@ const addMain = (packageRoot, task) => {
       return;
     }
     packageJson.main = "./dist/main.js";
-    writeFileSync(pathToPackageJson, JSON.stringify(packageJson));
+    writeFileSync(pathToPackageJson, JSON.stringify(packageJson, 2, 2));
   } catch (e) {
     throw e;
   }
@@ -162,34 +183,13 @@ try {
       title: "Reformat code in project",
       task: formatFiles,
     },
-
-    /**
-     * Add this for a more create-react-app example,
-     * maybe we'll need this later.
-     */
-    // {
-    //   title: "Add sample app",
-    //   task: addApp,
-    // },
   ]);
   tasks.run(packageRoot);
 } catch (e) {
   console.error(e);
 }
 
-/**
- *  This would give you a react app out of the
- * box, but let's not use it for now.
- */
-
-// const addApp = (packageRoot, task) => {
-//   if (pathExistsSync(join(packageRoot, "src"))) {
-//     task.skip("`src` folder already exists");
-//     return;
-//   }
-//   try {
-//     copySync(join(__dirname, "assets/src"), join(packageRoot, "src"));
-//   } catch (e) {
-//     throw e;
-//   }
-// };
+// Methods exported for tests
+module.exports = {
+  replaceScripts: replaceScripts
+}

--- a/install.js
+++ b/install.js
@@ -79,7 +79,6 @@ const installStaticFiles = (packageRoot, task) => {
  */
 const replaceScripts = (scripts, packageJson) => {
   Object.entries(scripts).forEach(([scriptName, scriptContents]) => {
-    const scriptContents = scriptData[1]
     if (!packageJson.scripts[scriptName]) {
       packageJson.scripts[scriptName] = scriptContents;
       return;

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,6 @@ module.exports = {
   transform: {
     "^.+\\.tsx?$": "ts-jest",
   },
-  testRegex: "(/__tests__/.*|\\.(test|spec))(?<!d)\\.(ts|tsx)$",
+  testRegex: "(/__tests__/.*|\\.(test|spec))(?<!d)\\.(ts|tsx|js)$",
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
 };

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   "main": "./index.js",
   "scripts": {
     "precommit": "lint-staged",
-    "postinstall": "node install.js"
+    "postinstall": "node install.js",
+    "test": "jest"
   },
   "files": [
     ".gitignore",


### PR DESCRIPTION
# Why

This PR makes it so that scripts are only overridden if they do not contain the defaults mandated by `operational-scripts`. Users can then add additional commands without them being overridden on install. Fixes #18.

# In this PR

This unobtrusive script override is implemented for `start`, `build`, `prepublishOnly` and `test`.

# How to Test / Please try to break

Unit test coming soon
