### PR TITLE
Disable doctoc

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,6 +1,5 @@
 {
     "*.md": [
-      "node index.js toc",
       "node index.js prettify",
       "git add"
     ],

--- a/assets/.lintstagedrc
+++ b/assets/.lintstagedrc
@@ -1,6 +1,5 @@
 {
     "*.md": [
-      "operational-scripts toc",
       "operational-scripts prettify",
       "git add"
     ],


### PR DESCRIPTION
# Why
This PR removes the automatic table of contents in each markdown file on precommit because it's annoying.