### PR TITLE
Enable multi-tenancy

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,7 +46,7 @@ const defaultConfig = {
     // These "chunks" are automatically generated with dynamic import();
     chunkFilename: "[name].[contenthash].js",
     path: outputDir,
-    publicPath: "/",
+    publicPath: "",
   },
   node: {
     fs: "empty",


### PR DESCRIPTION
# Why
Removes slash from operational scripts `basepath` to Enable multi-tenancy

Reference: https://github.com/contiamo/contiamo-ui/commit/25af99e423354f9baab5d0b4c2af2f6dfb28fad1